### PR TITLE
[DEV-431] - Fix position of modal drawer

### DIFF
--- a/src/organisms/modal-drawer/styles.tsx
+++ b/src/organisms/modal-drawer/styles.tsx
@@ -12,11 +12,11 @@ const { bold } = fontWeight;
 
 const slideInLeft = keyframes`
   from {
-    transform: translate3d(100%, 0, 0);
+    transform: translateX(100%);
   }
 
   to {
-    transform: translate3d(0, 0, 0);
+    transform: translateX(0);
   }
 `;
 
@@ -42,11 +42,11 @@ export const ModalWrapper = styled.div<ModalStyleBaseProps>`
 `;
 
 export const ModalContainer = styled.div<ModalStyleBaseProps>`
-  position: absolute;
+  position: fixed;
   right: 0;
   background: ${light};
   width: 100%;
-  min-height: 100vh;
+  height: 100vh;
   display: flex;
   flex-direction: column;
   padding: ${rem('15px')};
@@ -54,8 +54,9 @@ export const ModalContainer = styled.div<ModalStyleBaseProps>`
   animation-timing-function: ${timingFunctions('easeOutQuint')};
   animation-duration: 1s;
   animation-fill-mode: forwards;
-  transform: translate3d(100%, 0, 0);
+  transform: translateX(100%);
   animation-name: ${slideInLeft};
+  overflow-y: auto;
 
   @media ${device.s} {
     max-width: ${rem('400px')};


### PR DESCRIPTION
Ok, this one is one of that weird bugs that happens only in Safari and only in the first render (but not always). 😅
The problem is related to the `position` and the `translate` position of the container.

In Firefox and Chrome works well, and the container overflows the viewport and appears in the correct place:

![Screen Shot 2022-06-09 at 11 05 49](https://user-images.githubusercontent.com/2805206/172835779-cd24b7db-b824-4b55-9040-557bb48f5b86.png)

But on Safari, sometimes, on the first render, the container doesn't render the `translate` property well and does not overflow the viewport. Only when we interact with the view or the window (e.g., open dev tools, resize, etc.)

![CleanShot 2022-06-09 at 11 05 54](https://user-images.githubusercontent.com/2805206/172835770-e6ff8005-b7ed-4efa-90ff-0b7478bd8415.png)

 I tried some workarounds, but this approach was the only one that worked. 😅