### PR TITLE
[TKAI-HOTFIX]: Body content scrolling when modal is open

### DIFF
--- a/src/organisms/modal-drawer/index.tsx
+++ b/src/organisms/modal-drawer/index.tsx
@@ -27,6 +27,14 @@ const ModalDrawer = (props: ModalDrawerProps) => {
   } = props;
 
   useEffect(() => {
+    if (isShowing && typeof window !== 'undefined') {
+      document.documentElement.style.overflow = 'hidden';
+    } else {
+      document.documentElement.style.overflow = '';
+    }
+  }, [isShowing]);
+
+  useEffect(() => {
     const fixViewport = () => {
       let vh = window.innerHeight * 0.01;
       document.documentElement.style.setProperty('--vh', `${vh}px`);


### PR DESCRIPTION
Whenever the `modal drawer` is opened, a user can both scroll inside the `drawer` but also unconsciously through the `whole page (body)`. To fix it, when the modal is opened, the body needs to be set to `overflow: hidden`.

Setting the style property in `document.body.style...` does not work once the package is published. Even though it works fantastic in Storybook, it only sets the style to the closest `body` (in cases where the modal is inside a `iframe`).

So, I set it directly to `document.documentElement`, which also works. 